### PR TITLE
cmake: include GNUInstallDirs after project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 
+# Get version
+file(READ "${CMAKE_SOURCE_DIR}/VERSION" VER_RAW)
+string(STRIP ${VER_RAW} VER)
+
+project(hyprland-qt-support VERSION ${VER} LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -7,12 +13,6 @@ include(GNUInstallDirs)
 include(cmake/install-qml-module.cmake)
 
 option(BUILD_TESTER "Build style tester" OFF)
-
-# Get version
-file(READ "${CMAKE_SOURCE_DIR}/VERSION" VER_RAW)
-string(STRIP ${VER_RAW} VER)
-
-project(hyprland-qt-support VERSION ${VER} LANGUAGES CXX)
 
 find_package(Qt6 6.6 REQUIRED COMPONENTS Qml Quick QuickControls2)
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
Fixes the following warning:
```
CMake Warning (dev) at /usr/share/cmake/Modules/GNUInstallDirs.cmake:253 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
```
