### PR TITLE
Add missing PkgConfig:: qualifier to hyprlang import

### DIFF
--- a/src/style/impl/CMakeLists.txt
+++ b/src/style/impl/CMakeLists.txt
@@ -13,6 +13,6 @@ qt_add_qml_module(hyprland-quick-style-impl
         MotionBehavior.qml
 )
 
-target_link_libraries(hyprland-quick-style-impl PRIVATE Qt::Quick hyprlang)
+target_link_libraries(hyprland-quick-style-impl PRIVATE Qt::Quick PkgConfig::hyprlang)
 
 install_qml_module(hyprland-quick-style-impl)


### PR DESCRIPTION
That propagates PkgConfig info related to hyprlang that was set when pkg_check_modules searched for it.

Fixes #3 .