### PR TITLE
Adding style support for ToolButton

### DIFF
--- a/src/style/CMakeLists.txt
+++ b/src/style/CMakeLists.txt
@@ -13,6 +13,7 @@ qt_add_qml_module(hyprland-quick-style SHARED
     QML_FILES
         Button.qml
         CheckBox.qml
+        ToolButton.qml
         TextField.qml
 )
 

--- a/src/style/ToolButton.qml
+++ b/src/style/ToolButton.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import QtQuick.Templates as T
+import org.hyprland.style.impl
+
+import QtQuick.Controls.impl as ControlsPrivate
+
+T.ToolButton {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, implicitContentHeight + topPadding + bottomPadding)
+
+    padding: 6
+    spacing: 6
+
+    icon.width: 24
+    icon.height: 24
+    icon.color: control.palette.buttonText
+
+    contentItem: ControlsPrivate.IconLabel {
+        spacing: control.spacing
+        mirrored: control.mirrored
+        display: control.display
+
+        icon: control.icon
+        text: control.text
+        font: control.font
+        color: control.palette.buttonText
+    }
+
+    background: Rectangle {
+        implicitWidth: 50
+        implicitHeight: 30
+
+        radius: {
+            switch (HyprlandStyle.roundness) {
+            case 0: return 0;
+            case 1: return 4;
+            case 2: return 8;
+            case 3: return 16;
+            }
+        }
+
+        border.width: HyprlandStyle.borderWidth
+
+        MotionBehavior on color { ColorAnimation { duration: 60 } }
+        color: {
+            let highlightTint = control.down || control.checked ? 0.3 : control.highlighted ? 0.25 : 0.0;
+
+            if (control.flat && highlightTint)
+                highlightTint += 0.3;
+
+            const base = HyprlandStyle.flat(control.palette.button, control.flat);
+            return HyprlandStyle.overlay(base, control.palette.highlight, highlightTint);
+        }
+
+        MotionBehavior on border.color { ColorAnimation { duration: 60 } }
+        border.color: {
+            let highlightTint = control.down || control.checked ? 1.0 : (control.enabled && control.hovered) || control.highlighted ? control.flat ? 0.8 : 0.6 : 0.0;
+
+            const base = HyprlandStyle.flat(HyprlandStyle.lightenOrDarken(control.palette.button, 1.4), control.flat);
+            return HyprlandStyle.overlay(base, control.palette.highlight, highlightTint);
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: -1
+            radius: parent.radius + 1
+            color: "transparent"
+
+            MotionBehavior on border.color { ColorAnimation { duration: 60 } }
+            border.color: control.visualFocus ? Qt.alpha(control.palette.highlight, 0.8) : "transparent"
+        }
+    }
+}

--- a/src/style/test/main.qml
+++ b/src/style/test/main.qml
@@ -57,6 +57,25 @@ ApplicationWindow {
                 }
             }
 
+            ColumnLayout {
+                Layout.fillWidth: true
+                Label { text: "ToolButton" }
+
+                RowLayout{
+                    spacing: 4
+                    ToolButton { text: "Normal" }
+                    ToolButton { text: "Flat"; flat: true }
+                    ToolButton { text: "Down"; down: true }
+                    ToolButton { text: "Checked"; checkable: true; checked: true }
+                    ToolButton { text: "Highlighted"; highlighted: true }
+                    ToolButton { text: "Disabled"; enabled: false }
+                    ToolButton { text: "Flat Down"; flat: true; down: true }
+                    ToolButton { text: "Flat Checked"; flat: true; checkable: true; checked: true }
+                    ToolButton { text: "Flat Highlighted"; flat: true; highlighted: true }
+                    ToolButton { icon.name: "folder" }
+                }
+            }
+
             RowLayout {
                 ColumnLayout {
                     Layout.maximumWidth: 300


### PR DESCRIPTION
Using some qml applications I noticed that for some reason the ToolButton is not using the Button style.  I completed the tests and this was confirmed.
So I added a small fix for this

Before:
<img width="941" height="501" alt="изображение" src="https://github.com/user-attachments/assets/48bd287e-8fdd-404a-b532-ce60b264d0bf" />

After:
<img width="941" height="501" alt="изображение" src="https://github.com/user-attachments/assets/460541af-b5b4-43ce-a379-c10d2d8971ec" />
