### PR TITLE
qml: add style support for Menu, MenuItem and MenuSeparator

### DIFF
--- a/src/style/CMakeLists.txt
+++ b/src/style/CMakeLists.txt
@@ -13,6 +13,9 @@ qt_add_qml_module(hyprland-quick-style SHARED
     QML_FILES
         Button.qml
         CheckBox.qml
+        Menu.qml
+        MenuItem.qml
+        MenuSeparator.qml
         ToolButton.qml
         TextField.qml
 )

--- a/src/style/Menu.qml
+++ b/src/style/Menu.qml
@@ -1,0 +1,57 @@
+import QtQuick
+import QtQuick.Templates as T
+import QtQuick.Window
+import org.hyprland.style.impl
+
+T.Menu {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding)
+
+    margins: 0
+    padding: 6
+    overlap: 1
+
+    delegate: MenuItem { }
+
+    contentItem: ListView {
+        implicitHeight: contentHeight
+        model: control.contentModel
+        interactive: Window.window
+                     ? contentHeight + control.topPadding + control.bottomPadding > control.height
+                     : false
+        clip: true
+        currentIndex: control.currentIndex
+
+        ScrollIndicator.vertical: ScrollIndicator { }
+    }
+
+    background: Rectangle {
+        implicitWidth: 200
+        implicitHeight: 40
+
+        radius: {
+            switch (HyprlandStyle.roundness) {
+            case 0: return 0;
+            case 1: return 4;
+            case 2: return 8;
+            case 3: return 16;
+            }
+        }
+
+        color: control.palette.window
+        border.width: HyprlandStyle.borderWidth
+        border.color: HyprlandStyle.lightenOrDarken(control.palette.button, 1.4)
+    }
+
+    T.Overlay.modal: Rectangle {
+        color: Qt.alpha(control.palette.shadow, 0.5)
+    }
+
+    T.Overlay.modeless: Rectangle {
+        color: Qt.alpha(control.palette.shadow, 0.12)
+    }
+}

--- a/src/style/MenuItem.qml
+++ b/src/style/MenuItem.qml
@@ -1,0 +1,91 @@
+import QtQuick
+import QtQuick.Templates as T
+import org.hyprland.style.impl
+
+// This is private and we shouldn't use it, however rewriting IconLabel and ColorImage would take
+// unnecessary low-level work for this module.
+import QtQuick.Controls.impl as ControlsPrivate
+
+T.MenuItem {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding,
+                             implicitIndicatorHeight + topPadding + bottomPadding)
+
+    padding: 6
+    spacing: 6
+
+    icon.width: 16
+    icon.height: 16
+    icon.color: control.palette.windowText
+
+    contentItem: ControlsPrivate.IconLabel {
+        readonly property real arrowPadding: control.subMenu && control.arrow ? control.arrow.width + control.spacing : 0
+        readonly property real indicatorPadding: control.checkable && control.indicator ? control.indicator.width + control.spacing : 0
+        leftPadding: !control.mirrored ? indicatorPadding : arrowPadding
+        rightPadding: control.mirrored ? indicatorPadding : arrowPadding
+
+        spacing: control.spacing
+        mirrored: control.mirrored
+        display: control.display
+        alignment: Qt.AlignLeft
+
+        icon: control.icon
+        text: control.text
+        font: control.font
+        color: control.enabled ? control.palette.windowText : control.palette.placeholderText
+    }
+
+    indicator: Item {
+        implicitWidth: 16
+        implicitHeight: 16
+
+        x: control.mirrored ? control.width - width - control.rightPadding : control.leftPadding
+        y: control.topPadding + (control.availableHeight - height) / 2
+        visible: control.checkable
+
+        CheckDelegate {
+            anchors.fill: parent
+            checkState: control.checked ? Qt.Checked : Qt.Unchecked
+            color: control.enabled ? control.palette.windowText : control.palette.placeholderText
+            visible: control.checked
+        }
+    }
+
+    arrow: Text {
+        x: control.mirrored ? control.leftPadding : control.width - width - control.rightPadding
+        y: control.topPadding + (control.availableHeight - height) / 2
+
+        visible: control.subMenu
+        text: control.mirrored ? "<" : ">"
+        font: control.font
+        color: control.enabled ? control.palette.windowText : control.palette.placeholderText
+    }
+
+    background: Rectangle {
+        implicitWidth: 200
+        implicitHeight: 32
+
+        radius: {
+            switch (HyprlandStyle.roundness) {
+            case 0: return 0;
+            case 1: return 4;
+            case 2: return 6;
+            case 3: return 8;
+            }
+        }
+
+        MotionBehavior on color { ColorAnimation { duration: 60 } }
+        color: {
+            let highlightTint = control.down ? 0.30 : control.highlighted ? 0.22 : 0.0;
+            return HyprlandStyle.overlay(control.palette.window, control.palette.highlight, highlightTint);
+        }
+
+        MotionBehavior on border.color { ColorAnimation { duration: 60 } }
+        border.width: control.highlighted ? 1 : 0
+        border.color: Qt.alpha(control.palette.highlight, 0.5)
+    }
+}

--- a/src/style/MenuSeparator.qml
+++ b/src/style/MenuSeparator.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import QtQuick.Templates as T
+import org.hyprland.style.impl
+
+T.MenuSeparator {
+    id: control
+
+    implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                            implicitContentWidth + leftPadding + rightPadding)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding)
+
+    padding: 2
+    verticalPadding: padding + 4
+    horizontalPadding: 6
+
+    contentItem: Rectangle {
+        implicitWidth: 188
+        implicitHeight: 1
+        color: HyprlandStyle.lightenOrDarken(control.palette.button, 1.25)
+    }
+}

--- a/src/style/test/main.qml
+++ b/src/style/test/main.qml
@@ -175,6 +175,34 @@ ApplicationWindow {
                     Item { Layout.fillHeight: true }
                 }
 
+                ColumnLayout {
+                    Layout.maximumWidth: 200
+                    Label { text: "Menu" }
+
+                    Button {
+                        text: "Open Menu"
+                        onClicked: demoMenu.open()
+
+                        Menu {
+                            id: demoMenu
+                            y: parent.height
+
+                            Action { text: "First Action" }
+                            MenuItem { text: "Checkable"; checkable: true; checked: true }
+                            Menu {
+                                title: "Submenu"
+
+                                MenuItem { text: "Nested Action" }
+                                MenuItem { text: "Another Nested" }
+                            }
+                            MenuSeparator { }
+                            MenuItem { text: "Disabled"; enabled: false }
+                        }
+                    }
+
+                    Item { Layout.fillHeight: true }
+                }
+
                 Item { Layout.fillWidth: true }
             }
         }


### PR DESCRIPTION
Corner rounding in the Menu now respects the settings

Before:
<img width="320" height="458" alt="изображение" src="https://github.com/user-attachments/assets/87ff6726-aa9d-4b8c-8060-2259baad106f" />

After:
<img width="319" height="500" alt="изображение" src="https://github.com/user-attachments/assets/83e1b49f-efbf-498e-a98c-7cfcd35a7bd0" />
